### PR TITLE
Make the send_message step function retry on HTTP errors

### DIFF
--- a/module/stepfunctions_send_message.tf
+++ b/module/stepfunctions_send_message.tf
@@ -81,6 +81,7 @@ resource "aws_sfn_state_machine" "send_message" {
           {
             BackoffRate = 2
             ErrorEquals = [
+              "HTTPError",
               "Lambda.ServiceException",
               "Lambda.AWSLambdaException",
               "Lambda.SdkClientException",


### PR DESCRIPTION
https://nhsd-jira.digital.nhs.uk/browse/EM-811 If you haven't got access to the ticket, here is a brief summary.

The MNS project, which uses the MESH AWS client, has been looking into error scenarios for the new functionality we are developing.

We were looking into what happens in the rare case (platinum service) of a MESH outage.

The MESH serverless client [application code](https://github.com/NHSDigital/terraform-aws-mesh-client/blob/develop/src/mesh_send_message_chunk_application.py) ultimately inherits from the MESH Python client code for its send functionality: https://github.com/NHSDigital/mesh-client/blob/2c2d6d9cfdf15ee8f0c839e410285adfe08c76d0/mesh_client/__init__.py#L616 Here, you can see it only attempts to send once and will .raise_for_status (returning an HTTP error) if there is some sort of failure.

The outer wrapper for the step functions uses the following config: https://github.com/NHSDigital/terraform-aws-mesh-client/blob/2e019ecdac9904d0038ca6c5fc91eeeac82e99c5/module/stepfunctions_send_message.tf#L41

The retry behaviour is as follows:

Retry 1, wait 2 seconds
Retry 2, wait 4 seconds
Retry 3, wait 8 seconds
Retry 4, wait 16 seconds
Retry 5, wait 32 seconds
Retry 6, wait 64 seconds

We have separate tickets to look at setting up alarms and creating a retry script. However, given that MESH is a platinum service and this is a very robust retry pattern, I think we'd be covered for all but the most unlikely scenario.

There is an issue though, the step function is only looking out for the following error codes: "Lambda.ServiceException", "Lambda.AWSLambdaException", "Lambda.SdkClientException". In the case of an HTTPError it fails immediately.

We think it should also retry on HTTP errors. Apologies if this is was an intentional omission and users are meant to handle such scenarios in a different way. However, we thought this would be an improvement.