### PR TITLE
EM-933 Infra changes preceding work on the ticket

### DIFF
--- a/.github/actions/build-common/action.yml
+++ b/.github/actions/build-common/action.yml
@@ -5,6 +5,10 @@ inputs:
      required: false
      default: "false"
      description: "whether to configure aws credentials"
+   force-python-version:
+     required: false
+     default: ""
+     description: "provide a specific python version (see setup-python action docs) or empty string to use the version specified in pyproject.toml"
 
 
 runs:
@@ -38,10 +42,17 @@ runs:
           git checkout -b "merging-${{ github.event.number }}"
           git merge --ff-only "${{ github.event.pull_request.head.sha }}"
 
-      - name: setup python
-        uses: actions/setup-python@v4
+      - name: setup python using pyproject.toml
+        if: ${{ inputs.force-python-version == "" }}
+        uses: actions/setup-python@v5
         with:
           python-version-file: 'pyproject.toml'
+
+      - name: setup specific python version
+        if: ${{ inputs.force-python-version != "" }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.force-python-version }}
 
       - name: install terraform
         uses: hashicorp/setup-terraform@v2

--- a/.github/actions/build-common/action.yml
+++ b/.github/actions/build-common/action.yml
@@ -43,13 +43,13 @@ runs:
           git merge --ff-only "${{ github.event.pull_request.head.sha }}"
 
       - name: setup python using pyproject.toml
-        if: ${{ inputs.force-python-version == "" }}
+        if: ${{ inputs.force-python-version == '' }}
         uses: actions/setup-python@v5
         with:
           python-version-file: 'pyproject.toml'
 
       - name: setup specific python version
-        if: ${{ inputs.force-python-version != "" }}
+        if: ${{ inputs.force-python-version != '' }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.force-python-version }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -52,6 +52,38 @@ jobs:
         if: success() || failure()
         run: make down
 
+  tox:
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    runs-on: ubuntu-latest
+    if: github.repository == 'NHSDigital/terraform-aws-mesh-client'
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: common build setup
+        uses: ./.github/actions/build-common
+
+      - name: ci install
+        uses: ./.github/actions/install-ci
+
+      - name: black
+        run: make black-check
+
+      - name: start localstack
+        run: make up-ci
+
+      - name: run tests in tox
+        run: make tox
+
+      - name: stop docker containers
+        if: success() || failure()
+        run: make down
+
   lint:
     runs-on: ubuntu-latest
     if: github.repository == 'NHSDigital/terraform-aws-mesh-client'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -67,9 +67,14 @@ jobs:
 
       - name: common build setup
         uses: ./.github/actions/build-common
+        with:
+          force-python-version: ${{ matrix.python-version }}
 
       - name: ci install
         uses: ./.github/actions/install-ci
+
+      - name: install tox-github-ci plugin
+        run: pip install tox-gh-actions
 
       - name: black
         run: make black-check

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,9 @@ pytest: certs
 
 test: pytest
 
+tox:
+	poetry run tox
+
 tflint:
 	@docker run -v "$(pwd)/module:/data" -v "$(pwd)/tflint.hcl:/tflint.hcl" --entrypoint=/bin/sh \
 		ghcr.io/terraform-linters/tflint \

--- a/poetry.lock
+++ b/poetry.lock
@@ -556,6 +556,17 @@ types-awscrt = "*"
 botocore = ["botocore"]
 
 [[package]]
+name = "cachetools"
+version = "5.5.0"
+description = "Extensible memoizing collections and decorators"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "cachetools-5.5.0-py3-none-any.whl", hash = "sha256:02134e8439cdc2ffb62023ce1debca2944c3f289d66bb17ead3ab3dede74b292"},
+    {file = "cachetools-5.5.0.tar.gz", hash = "sha256:2cc24fb4cbe39633fb7badd9db9ca6295d766d9c2995f245725a46715d050f2a"},
+]
+
+[[package]]
 name = "certifi"
 version = "2024.7.4"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -629,6 +640,17 @@ files = [
 
 [package.dependencies]
 pycparser = "*"
+
+[[package]]
+name = "chardet"
+version = "5.2.0"
+description = "Universal encoding detector for Python 3"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970"},
+    {file = "chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7"},
+]
 
 [[package]]
 name = "charset-normalizer"
@@ -866,6 +888,33 @@ sdist = ["build"]
 ssh = ["bcrypt (>=3.1.5)"]
 test = ["certifi", "cryptography-vectors (==43.0.0)", "pretend", "pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-xdist"]
 test-randomorder = ["pytest-randomly"]
+
+[[package]]
+name = "distlib"
+version = "0.3.8"
+description = "Distribution utilities"
+optional = false
+python-versions = "*"
+files = [
+    {file = "distlib-0.3.8-py2.py3-none-any.whl", hash = "sha256:034db59a0b96f8ca18035f36290806a9a6e6bd9d1ff91e45a7f172eb17e51784"},
+    {file = "distlib-0.3.8.tar.gz", hash = "sha256:1530ea13e350031b6312d8580ddb6b27a104275a31106523b8f123787f494f64"},
+]
+
+[[package]]
+name = "filelock"
+version = "3.16.0"
+description = "A platform independent file lock."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "filelock-3.16.0-py3-none-any.whl", hash = "sha256:f6ed4c963184f4c84dd5557ce8fece759a3724b37b80c6c4f20a2f63a4dc6609"},
+    {file = "filelock-3.16.0.tar.gz", hash = "sha256:81de9eb8453c769b63369f87f11131a7ab04e367f8d97ad39dc230daa07e3bec"},
+]
+
+[package.extras]
+docs = ["furo (>=2024.8.6)", "sphinx (>=8.0.2)", "sphinx-autodoc-typehints (>=2.4)"]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.6.1)", "diff-cover (>=9.1.1)", "pytest (>=8.3.2)", "pytest-asyncio (>=0.24)", "pytest-cov (>=5)", "pytest-mock (>=3.14)", "pytest-timeout (>=2.3.1)", "virtualenv (>=20.26.3)"]
+typing = ["typing-extensions (>=4.12.2)"]
 
 [[package]]
 name = "idna"
@@ -1451,6 +1500,24 @@ files = [
 ]
 
 [[package]]
+name = "pyproject-api"
+version = "1.7.1"
+description = "API to interact with the python pyproject.toml based projects"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pyproject_api-1.7.1-py3-none-any.whl", hash = "sha256:2dc1654062c2b27733d8fd4cdda672b22fe8741ef1dde8e3a998a9547b071eeb"},
+    {file = "pyproject_api-1.7.1.tar.gz", hash = "sha256:7ebc6cd10710f89f4cf2a2731710a98abce37ebff19427116ff2174c9236a827"},
+]
+
+[package.dependencies]
+packaging = ">=24.1"
+
+[package.extras]
+docs = ["furo (>=2024.5.6)", "sphinx-autodoc-typehints (>=2.2.1)"]
+testing = ["covdefaults (>=2.3)", "pytest (>=8.2.2)", "pytest-cov (>=5)", "pytest-mock (>=3.14)", "setuptools (>=70.1)"]
+
+[[package]]
 name = "pytest"
 version = "8.3.2"
 description = "pytest: simple powerful testing with Python"
@@ -1673,6 +1740,32 @@ aws-lambda-powertools = "*"
 six = "*"
 
 [[package]]
+name = "tox"
+version = "4.18.1"
+description = "tox is a generic virtualenv management and test command line tool"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "tox-4.18.1-py3-none-any.whl", hash = "sha256:35d472032ee1f73fe20c3e0e73d7073a4e85075c86ff02c576f9fc7c6a15a578"},
+    {file = "tox-4.18.1.tar.gz", hash = "sha256:3c0c96bc3a568a5c7e66387a4cfcf8c875b52e09f4d47c9f7a277ec82f1a0b11"},
+]
+
+[package.dependencies]
+cachetools = ">=5.5"
+chardet = ">=5.2"
+colorama = ">=0.4.6"
+filelock = ">=3.15.4"
+packaging = ">=24.1"
+platformdirs = ">=4.2.2"
+pluggy = ">=1.5"
+pyproject-api = ">=1.7.1"
+virtualenv = ">=20.26.3"
+
+[package.extras]
+docs = ["furo (>=2024.8.6)", "sphinx (>=8.0.2)", "sphinx-argparse-cli (>=1.17)", "sphinx-autodoc-typehints (>=2.4)", "sphinx-copybutton (>=0.5.2)", "sphinx-inline-tabs (>=2023.4.21)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=24.8)"]
+testing = ["build[virtualenv] (>=1.2.2)", "covdefaults (>=2.3)", "detect-test-pollution (>=1.2)", "devpi-process (>=1)", "diff-cover (>=9.1.1)", "distlib (>=0.3.8)", "flaky (>=3.8.1)", "hatch-vcs (>=0.4)", "hatchling (>=1.25)", "psutil (>=6)", "pytest (>=8.3.2)", "pytest-cov (>=5)", "pytest-mock (>=3.14)", "pytest-xdist (>=3.6.1)", "re-assert (>=1.1)", "setuptools (>=74.1.2)", "time-machine (>=2.15)", "wheel (>=0.44)"]
+
+[[package]]
 name = "types-awscrt"
 version = "0.21.2"
 description = "Type annotations and code completion for awscrt"
@@ -1723,6 +1816,26 @@ socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
+name = "virtualenv"
+version = "20.26.4"
+description = "Virtual Python Environment builder"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "virtualenv-20.26.4-py3-none-any.whl", hash = "sha256:48f2695d9809277003f30776d155615ffc11328e6a0a8c1f0ec80188d7874a55"},
+    {file = "virtualenv-20.26.4.tar.gz", hash = "sha256:c17f4e0f3e6036e9f26700446f85c76ab11df65ff6d8a9cbfad9f71aabfcf23c"},
+]
+
+[package.dependencies]
+distlib = ">=0.3.7,<1"
+filelock = ">=3.12.2,<4"
+platformdirs = ">=3.9.1,<5"
+
+[package.extras]
+docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.2,!=7.3)", "sphinx-argparse (>=0.4)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=23.6)"]
+test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.4)", "pytest-env (>=0.8.2)", "pytest-freezer (>=0.4.8)", "pytest-mock (>=3.11.1)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=68)", "time-machine (>=2.10)"]
+
+[[package]]
 name = "werkzeug"
 version = "3.0.3"
 description = "The comprehensive WSGI web application library."
@@ -1768,4 +1881,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "4f3cb9e367a94edf1e343fdb52c33cbb35c9fba4d2565e9c7b29932113b1f351"
+content-hash = "db2caf6ba5dd7262085db519c37312fbbb5e9eaf4a8ef9682cce6e3a8aad0fa2"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1527,6 +1527,7 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -1766,5 +1767,5 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 
 [metadata]
 lock-version = "2.0"
-python-versions = "~3.11"
-content-hash = "5bea73ad4d3fb7a0374858df985558191e9a94d3628cfa82a98dad61cfa59715"
+python-versions = "^3.11"
+content-hash = "4f3cb9e367a94edf1e343fdb52c33cbb35c9fba4d2565e9c7b29932113b1f351"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,6 +154,10 @@ legacy_tox_ini = """
         py311
         py312
 
+    [gh-actions]
+    python =
+        3.11: py310
+        3.12: py312
 
     [testenv]
     allowlist_externals = poetry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,7 +156,7 @@ legacy_tox_ini = """
 
     [gh-actions]
     python =
-        3.11: py310
+        3.11: py311
         3.12: py312
 
     [testenv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ boto3-stubs = {extras = ["s3", "ssm", "secretsmanager", "dynamodb", "stepfunctio
 ruff = "^0"
 petname = "^2.6"
 black = "^24"
+tox = "^4.18"
 
 [tool.poetry.group.local.dependencies]
 
@@ -144,6 +145,29 @@ show_missing = true
 
 [tool.coverage.xml]
 output = "reports/coverage.xml"
+
+[tool.tox]
+legacy_tox_ini = """
+    [tox]
+    min-version=3.1
+    env_list =
+        py311
+        py312
+
+
+    [testenv]
+    allowlist_externals = poetry
+    setenv =
+        PYTHONPATH = src/
+    deps =
+        pytest
+        pytest-asyncio
+        moto
+        boto3
+        petname
+    commands =
+        pytest
+"""
 
 
 [build-system]

--- a/scripts/self-signed-ca/conf/client.conf
+++ b/scripts/self-signed-ca/conf/client.conf
@@ -36,4 +36,3 @@ nsCertType             = client
 keyUsage               = critical, nonRepudiation, digitalSignature, keyEncipherment
 extendedKeyUsage       = critical, clientAuth, codeSigning
 subjectKeyIdentifier   = hash
-authorityKeyIdentifier = keyid, issuer

--- a/scripts/self-signed-ca/conf/server.conf
+++ b/scripts/self-signed-ca/conf/server.conf
@@ -19,6 +19,4 @@ emailAddress = mesh.spine@hscic.gov.uk
 [ v3_req ]
 keyUsage         = nonRepudiation, digitalSignature, keyEncipherment, keyAgreement
 extendedKeyUsage = critical, serverAuth
-
-[ req_ext ]
 subjectAltName   = $ENV::SAN

--- a/scripts/self-signed-ca/conf/server.conf
+++ b/scripts/self-signed-ca/conf/server.conf
@@ -19,3 +19,6 @@ emailAddress = mesh.spine@hscic.gov.uk
 [ v3_req ]
 keyUsage         = nonRepudiation, digitalSignature, keyEncipherment, keyAgreement
 extendedKeyUsage = critical, serverAuth
+
+[ req_ext ]
+subjectAltName   = $ENV::SAN

--- a/scripts/self-signed-ca/create-server-cert.sh
+++ b/scripts/self-signed-ca/create-server-cert.sh
@@ -32,13 +32,13 @@ echo -e "Generating websvr key and csr:\n"
 csr_conf="${this_dir}/conf/server.conf"
 
 if [[ ${dns_name2} == "?" ]]; then
-  san="subjectAltName = DNS:${dns_name1}"
+  export SAN="subjectAltName=DNS:${dns_name1}"
 else
-  san="subjectAltName = DNS:${dns_name1}, DNS:${dns_name2}"
+  export SAN="subjectAltName=DNS:${dns_name1},DNS:${dns_name2}"
 fi
 
 export CN="${dns_name1}"
-openssl req -newkey rsa:2048 -nodes -keyout "${cert_key}" -new -out "${cert_csr}" -config "${csr_conf}" -extensions v3_req -addext "${san}"
+openssl req -newkey rsa:2048 -nodes -keyout "${cert_key}" -new -out "${cert_csr}" -config "${csr_conf}" -extensions v3_req
 
 #extra_extensions=""
 #if [[ "${type}" == "client" ]]; then

--- a/scripts/self-signed-ca/create-server-cert.sh
+++ b/scripts/self-signed-ca/create-server-cert.sh
@@ -32,9 +32,9 @@ echo -e "Generating websvr key and csr:\n"
 csr_conf="${this_dir}/conf/server.conf"
 
 if [[ ${dns_name2} == "?" ]]; then
-  export SAN="subjectAltName=DNS:${dns_name1}"
+  export SAN="DNS:${dns_name1}"
 else
-  export SAN="subjectAltName=DNS:${dns_name1},DNS:${dns_name2}"
+  export SAN="DNS:${dns_name1},DNS:${dns_name2}"
 fi
 
 export CN="${dns_name1}"

--- a/src/shared/common.py
+++ b/src/shared/common.py
@@ -8,6 +8,9 @@ from mypy_boto3_ssm import SSMClient
 from mypy_boto3_stepfunctions import SFNClient
 from nhs_aws_helpers import secrets_client, ssm_client, stepfunctions
 
+BOOL_TRUE_SET = {"yes", "true", "t", "y", "1"}
+BOOL_FALSE_SET = {"no", "false", "f", "n", "0"}
+
 
 class SingletonCheckFailure(Exception):
     """Singleton check failed"""
@@ -30,6 +33,20 @@ def nullsafe_quote(value: str | None) -> str:
         return ""
 
     return quote_plus(value, encoding="utf-8")
+
+
+def strtobool(value, raise_exc=False):
+    if isinstance(value, str):
+        value = value.lower()
+        if value in BOOL_TRUE_SET:
+            return True
+        if value in BOOL_FALSE_SET:
+            return False
+
+    if raise_exc:
+        list_str = '", "'.join(BOOL_TRUE_SET | BOOL_FALSE_SET)
+        raise ValueError(f'Expected "{list_str}"')
+    return None
 
 
 def singleton_check(

--- a/src/shared/common.py
+++ b/src/shared/common.py
@@ -8,8 +8,8 @@ from mypy_boto3_ssm import SSMClient
 from mypy_boto3_stepfunctions import SFNClient
 from nhs_aws_helpers import secrets_client, ssm_client, stepfunctions
 
-BOOL_TRUE_SET = {"yes", "true", "t", "y", "1"}
-BOOL_FALSE_SET = {"no", "false", "f", "n", "0"}
+BOOL_TRUE_VALUES = ["yes", "true", "t", "y", "1"]
+BOOL_FALSE_VALUES = ["no", "false", "f", "n", "0"]
 
 
 class SingletonCheckFailure(Exception):
@@ -38,13 +38,13 @@ def nullsafe_quote(value: str | None) -> str:
 def strtobool(value, raise_exc=False):
     if isinstance(value, str):
         value = value.lower()
-        if value in BOOL_TRUE_SET:
+        if value in BOOL_TRUE_VALUES:
             return True
-        if value in BOOL_FALSE_SET:
+        if value in BOOL_FALSE_VALUES:
             return False
 
     if raise_exc:
-        list_str = '", "'.join(BOOL_TRUE_SET | BOOL_FALSE_SET)
+        list_str = '", "'.join(BOOL_TRUE_VALUES + BOOL_FALSE_VALUES)
         raise ValueError(f'Expected "{list_str}"')
     return None
 

--- a/src/shared/send_parameters.py
+++ b/src/shared/send_parameters.py
@@ -1,6 +1,5 @@
 import os
 from dataclasses import dataclass
-from distutils.util import strtobool
 from math import ceil
 from typing import Any
 from urllib.parse import unquote_plus
@@ -10,7 +9,7 @@ from mypy_boto3_s3.service_resource import Object
 from mypy_boto3_ssm import SSMClient
 from nhs_aws_helpers import ssm_client
 
-from shared.common import convert_params_to_dict
+from shared.common import convert_params_to_dict, strtobool
 from shared.config import EnvConfig
 
 _MESH_SEND_KWARGS = {

--- a/stacks/localstack/required_providers.tf
+++ b/stacks/localstack/required_providers.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+        source = "hashicorp/aws"
+        version = "5.66.0"
+    }
+  }
+}

--- a/tests/mocked/mesh_common_test.py
+++ b/tests/mocked/mesh_common_test.py
@@ -120,6 +120,6 @@ def test_strtobool_exception_raised(input_val):
         strtobool(input_val, True)
 
 
-@pytest.mark.parametrize("input_val",["HELLO", True, [], "YESH", 3, None])
+@pytest.mark.parametrize("input_val", ["HELLO", True, [], "YESH", 3, None])
 def test_strtobool_exception_swallowed(input_val):
     assert strtobool(input_val, False) is None

--- a/tests/mocked/mesh_common_test.py
+++ b/tests/mocked/mesh_common_test.py
@@ -2,9 +2,9 @@
 
 import re
 from collections.abc import Generator
-import pytest
 from uuid import uuid4
 
+import pytest
 from nhs_aws_helpers import secrets_client, ssm_client
 from shared.common import get_params, strtobool
 
@@ -100,52 +100,26 @@ def test_get_params_ssm_and_secrets(environment: str):
     }
     assert expected_params == param_dict
 
-@pytest.mark.parametrize("input_val", [
-    "True",
-    "true",
-    "1",
-    "Yes",
-    "Y",
-    "t",
-    "T"
-])
+
+@pytest.mark.parametrize("input_val", ["True", "true", "1", "Yes", "Y", "t", "T"])
 def test_strtobool_true(input_val):
     assert strtobool(input_val, False) is True
 
 
-@pytest.mark.parametrize("input_val", [
-    "False",
-    "false",
-    "0",
-    "No",
-    "N",
-    "f",
-    "F"
-])
+@pytest.mark.parametrize("input_val", ["False", "false", "0", "No", "N", "f", "F"])
 def test_strtobool_false(input_val):
     assert strtobool(input_val, False) is False
 
 
-@pytest.mark.parametrize("input_val", [
-    "HELLO",
-    True,
-    [],
-    "YESH",
-    3,
-    None
-])
+@pytest.mark.parametrize("input_val", ["HELLO", True, [], "YESH", 3, None])
 def test_strtobool_exception_raised(input_val):
-    with pytest.raises(ValueError, match='Expected "yes", "true", "t", "y", "1", "no", "false", "f", "n", "0"'):
+    with pytest.raises(
+        ValueError,
+        match='Expected "yes", "true", "t", "y", "1", "no", "false", "f", "n", "0"',
+    ):
         strtobool(input_val, True)
 
 
-@pytest.mark.parametrize("input_val", [
-   "HELLO",
-    True,
-    [],
-    "YESH",
-    3,
-    None
-])
+@pytest.mark.parametrize("input_val",["HELLO", True, [], "YESH", 3, None])
 def test_strtobool_exception_swallowed(input_val):
     assert strtobool(input_val, False) is None


### PR DESCRIPTION
A few changes which were required before starting real work on EM-933.
They boil down to:
- making the tests work properly in python 3.12
- breaking out builds to check both python 3.11 and 3.12
- fixing the self-signed cert configs to work with newer versions of openssl. This isn't vital, but will start to break as our distros move to 3.1+
- within `stacks/localstack`, pinned the Terraform AWS provider to version 5.66.0 as the new 5.67 release implements validation using `ValidateStateMachineDefinition` which isn't supported by localstack and therefore breaks dev builds.