### PR TITLE
MESH-2891: Use GitHub App credentials for the auto-merge to enable an…

### DIFF
--- a/.github/actions/build-common/action.yml
+++ b/.github/actions/build-common/action.yml
@@ -44,23 +44,23 @@ runs:
 
       - name: setup python using pyproject.toml
         if: ${{ inputs.force-python-version == '' }}
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version-file: 'pyproject.toml'
 
       - name: setup specific python version
         if: ${{ inputs.force-python-version != '' }}
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ inputs.force-python-version }}
 
       - name: install terraform
-        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_version: 1.4.5
 
       - name: install poetry
-        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
         with:
           version: 2.2.1
           virtualenvs-create: true

--- a/.github/actions/coverage-and-sonar/action.yml
+++ b/.github/actions/coverage-and-sonar/action.yml
@@ -17,7 +17,7 @@ runs:
 
     - name: code coverage report
       if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
-      uses: orgoro/coverage@c65003f41276ea33fe3a3a5d53df8b340462e8fa
+      uses: orgoro/coverage@ca0c362dc1a4f100447309405e6dfea47e251495 # v3.3.1
       with:
         coverageFile: reports/coverage.xml
         token: ${{ inputs.github-token }}
@@ -25,7 +25,7 @@ runs:
 
     - name: setup java
       if: success() || failure()
-      uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3
+      uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
       with:
         distribution: "corretto"
         java-version: "17"

--- a/.github/actions/install-ci/action.yml
+++ b/.github/actions/install-ci/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
 
     - name: cache virtualenv
-      uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
       with:
         path: |
           .venv

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,18 @@ updates:
       commit-message:
           prefix: "MESH-2092 github actions "
           include: scope
+      groups:
+        patch-and-minor:
+          patterns:
+            - "*"
+          update-types:
+            - "minor"
+            - "patch"
+        major:
+          patterns:
+            - "*"
+          update-types:
+            - "major"
 
     - package-ecosystem: "pip"
       directory: "/"
@@ -22,6 +34,21 @@ updates:
       commit-message:
           prefix: "MESH-2092 py dev "
           include: scope
+      groups:
+        patch-and-minor:
+          patterns:
+            - "*"
+          update-types:
+            - "minor"
+            - "patch"
+        major:
+          patterns:
+            - "*"
+          update-types:
+            - "major"
+      ignore:
+        # Pinned to exact version 8.0.0 in pyproject.toml - requires manual review to update
+        - dependency-name: "importlib-metadata"
 
     - package-ecosystem: "terraform"
       directories:
@@ -35,6 +62,18 @@ updates:
       commit-message:
           prefix: "MESH-2092 terraform "
           include: scope
+      groups:
+        patch-and-minor:
+          patterns:
+            - "*"
+          update-types:
+            - "minor"
+            - "patch"
+        major:
+          patterns:
+            - "*"
+          update-types:
+            - "major"
 
     - package-ecosystem: "docker"
       directory: "/"
@@ -46,3 +85,15 @@ updates:
       commit-message:
           prefix: "MESH-2092 docker "
           include: scope
+      groups:
+        patch-and-minor:
+          patterns:
+            - "*"
+          update-types:
+            - "minor"
+            - "patch"
+        major:
+          patterns:
+            - "*"
+          update-types:
+            - "major"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.repository == 'NHSDigital/terraform-aws-mesh-client' && !contains(github.event.head_commit.message, 'tag release version:')
     steps:
       - name: checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -25,7 +25,7 @@ jobs:
 
       - name: create release
         id: create_release
-        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1.1.4
         continue-on-error: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -1,44 +1,94 @@
 name: Auto-merge Dependabot PRs
 
 on:
-    pull_request:
-        types:
-            - opened
-            - reopened
-            - synchronize
-            - ready_for_review
-            - labeled
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - labeled
+
+# Intent:
+#   Dependabot PRs should be automatically approved and set to auto-merge.
+#   Auto-merge means GitHub will merge the PR as soon as all required checks pass.
+#
+#   If checks fail and a human intervenes by pushing a fix commit, the auto-approval
+#   should be invalidated - the PR must then be manually reviewed and approved before
+#   it can merge.
+#
+#   If checks fail and a human simply re-runs the workflow (no code change), the PR
+#   should re-approve and re-enable auto-merge on success - the human has decided to
+#   retry the original Dependabot change, so no fresh review is required.
+#
+# How the conditional satisfies this:
+#   `github.actor` is the user who triggered the *original* workflow run. Crucially,
+#   it is preserved across re-runs - if a human re-runs a Dependabot-triggered run,
+#   github.actor remains 'dependabot[bot]', so this job still fires and re-approves.
+#
+#   When a human pushes a commit to the branch, a new 'synchronize' event fires with
+#   github.actor set to that human - this job is skipped, the existing approval is
+#   dismissed by GitHub's branch protection (requires new review after new commits),
+#   and the PR must be manually approved before auto-merge can proceed.
 
 jobs:
-    enable-automerge:
-        # Only run on Dependabot PRs
-        if: github.actor == 'dependabot[bot]'
-        runs-on: ubuntu-latest
-        permissions:
-            contents: write
-            pull-requests: write
+  enable-automerge:
+    # Only run on Dependabot PRs
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
 
-        steps:
-            - name: Generate token from GitHub App
-              id: generate-token
-              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-              with:
-                  client-id: ${{ secrets.SHARED_MERGE_AND_WRITEBACK_APP_ID }}
-                  private-key: ${{ secrets.SHARED_MERGE_AND_WRITEBACK_APP_PRIVATE_KEY }}
+    steps:
+      - name: Generate token from GitHub App
+        id: generate-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.SHARED_MERGE_AND_WRITEBACK_APP_ID }}
+          private-key: ${{ secrets.SHARED_MERGE_AND_WRITEBACK_APP_PRIVATE_KEY }}
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
-            - name: Fetch Dependabot metadata
-              id: metadata
-              uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
-              with:
-                  github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Auto-approve Dependabot PR
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
-            - name: Auto-approve Dependabot PR
-              uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
-              with:
-                  github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Enable auto-merge for Dependabot PRs
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
 
-            - name: Enable auto-merge for Dependabot PRs
-              run: gh pr merge --auto --squash "$PR_URL"
-              env:
-                  PR_URL: ${{ github.event.pull_request.html_url }}
-                  GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+      - name: Notify Slack of manual review required
+        if: github.event.action == 'opened' && steps.metadata.outputs.update-type != 'version-update:semver-patch' && steps.metadata.outputs.update-type != 'version-update:semver-minor'
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        with:
+          webhook: ${{ secrets.DEPENDABOT_SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ":dependabot: DEPENDABOT UPDATE REQUIRES REVIEW :dependabot:",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "A Dependabot PR in ${{ github.repository }} is not a candidate for auto-merge (update-type: `${{ steps.metadata.outputs.update-type }}`). Manual review required: <https://github.com/${{ github.repository }}/pull/${{ github.event.number }}|PR #${{ github.event.number }}>"
+                  }
+                }
+              ]
+            }

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -19,6 +19,13 @@ jobs:
             pull-requests: write
 
         steps:
+            - name: Generate token from GitHub App
+              id: generate-token
+              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+              with:
+                  client-id: ${{ secrets.SHARED_MERGE_AND_WRITEBACK_APP_ID }}
+                  private-key: ${{ secrets.SHARED_MERGE_AND_WRITEBACK_APP_PRIVATE_KEY }}
+
             - name: Fetch Dependabot metadata
               id: metadata
               uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
@@ -34,4 +41,4 @@ jobs:
               run: gh pr merge --auto --squash "$PR_URL"
               env:
                   PR_URL: ${{ github.event.pull_request.html_url }}
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/merge-develop.yml
+++ b/.github/workflows/merge-develop.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.repository == 'NHSDigital/terraform-aws-mesh-client' && !contains(github.event.head_commit.message, 'tag release version:')
     steps:
       - name: checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -33,7 +33,7 @@ jobs:
 
       - name: publish junit reports
         if: success() || failure()
-        uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d
+        uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d # v6.4.1
         with:
           check_name: junit reports
           report_paths: reports/junit/*.xml

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.repository == 'NHSDigital/terraform-aws-mesh-client'
     steps:
       - name: checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -36,14 +36,14 @@ jobs:
 
       - name: archive reports
         if: github.actor != 'dependabot[bot]' && (success() || failure())
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: reports
           path: reports/**/*
 
       - name: publish junit reports
         if: success() || failure()
-        uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d
+        uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d # v6.4.1
         with:
           check_name: junit reports
           report_paths: reports/junit/*.xml
@@ -61,7 +61,7 @@ jobs:
     if: github.repository == 'NHSDigital/terraform-aws-mesh-client'
     steps:
       - name: checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -94,7 +94,7 @@ jobs:
     if: github.repository == 'NHSDigital/terraform-aws-mesh-client'
     steps:
       - name: checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -125,7 +125,7 @@ jobs:
         run: make mypy
 
       - name: shellcheck
-        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
         with:
           ignore_paths: .venv build
           ignore_names: git-secrets


### PR DESCRIPTION
…y post-merge Actions to run. (Also update version comments on pinned Actions so Dependabot will recognise and increment these when updating.)